### PR TITLE
 【修改】：micropython 默认可以不开启 DFS_POSIX API, 添加依赖宏。

### DIFF
--- a/port/mpy_main.c
+++ b/port/mpy_main.c
@@ -29,8 +29,11 @@
 #include <string.h>
 
 #include <rtthread.h>
-#include <dfs_posix.h>
 #include <shell.h>
+
+#ifdef RT_USING_DFS
+#include <dfs_posix.h>
+#endif
 
 #include <py/compile.h>
 #include <py/runtime.h>


### PR DESCRIPTION
使用 mp 默认没有开启 dfs， 但是却默认包含了 #include <dfs_posix.h> 头文件导致编译错误。