### PR TITLE
Include rthw.h header file to fix compiling issue in SMP

### DIFF
--- a/port/mpconfigport.h
+++ b/port/mpconfigport.h
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
+#include <rthw.h>
 #include <rtthread.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
在mpconfigport.h头文件中包含rthw.h头文件，以修正SMP环境下rt_hw_interrupt_disable/enable被定义到rt_cpus_lock/unlock而导致的编译出错的问题。