### PR TITLE
修改不能多个定时器同时使用回调函数的BUG

### DIFF
--- a/port/modules/machine/machine_timer.c
+++ b/port/modules/machine/machine_timer.c
@@ -39,6 +39,8 @@
 #include <drivers/hwtimer.h>
 #include "machine_timer.h"
 
+#define  MAX_TIMER  17
+
 typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
     rt_device_t timer_device;
@@ -90,12 +92,13 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
     self->timeout_cb = RT_NULL;
     self->is_repeat = RT_TRUE;
     self->is_init = RT_FALSE;
+	self->timer_device->device_id = device_id-1;
     
     // return constant object
     return MP_OBJ_FROM_PTR(self);
 }
 
-static machine_timer_obj_t *timer_self = RT_NULL;
+static machine_timer_obj_t *timer_self[MAX_TIMER] = {RT_NULL};
 
 STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     machine_timer_obj_t *self = self_in;
@@ -105,7 +108,7 @@ STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
         result = rt_device_close(self->timer_device);
         error_check(result == RT_EOK, "Timer device close error");
         self->is_init = RT_FALSE;
-        timer_self = RT_NULL;
+        timer_self[self->timer_device->device_id] = RT_NULL;
     }
 
     return mp_const_none;
@@ -113,7 +116,7 @@ STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
 STATIC rt_err_t timer_event_handler(rt_device_t dev, rt_size_t size) {
-    machine_timer_obj_t *self = timer_self;
+    machine_timer_obj_t *self = timer_self[dev->device_id];
 
     mp_sched_schedule(self->timeout_cb, MP_OBJ_FROM_PTR(self));
     return RT_EOK;
@@ -162,11 +165,11 @@ STATIC mp_obj_t machine_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_ma
     
     if (self->timeout_cb != RT_NULL) {
         // set callback timer
-        if (timer_self && timer_self != self) {
+        if (timer_self[self->timer_device->device_id] && timer_self[self->timer_device->device_id] != self) {
             // TODO add multi-timer device support
             error_check(result == RT_EOK, "Only supports one timer device work");
         } else {
-            timer_self = self;
+            timer_self[self->timer_device->device_id] = self;
         }
         result = rt_device_set_rx_indicate(self->timer_device, timer_event_handler);
         error_check(result == RT_EOK, "Timer set timout callback error");
@@ -194,9 +197,47 @@ STATIC mp_obj_t machine_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_ma
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);
 
+
+STATIC mp_obj_t machine_timer_callback(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    machine_timer_obj_t *self = (machine_timer_obj_t *)args[0];
+    rt_bool_t result = RT_EOK;
+    
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_callback,     MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+
+    mp_arg_val_t dargs[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, dargs);
+    
+    self->timeout_cb = dargs[0].u_obj;
+    
+    if(n_args == 1)
+    {
+		self->timeout_cb = RT_NULL;
+		self->timer_device->rx_indicate = RT_NULL;//注销回调函数
+    }
+    else if(n_args == 2)
+	{
+		if(self->timeout_cb != mp_const_none)
+		{
+			timer_self[self->timer_device->device_id] = self;
+			result = rt_device_set_rx_indicate(self->timer_device, timer_event_handler); //注册回调函数
+			error_check(result == RT_EOK, "Timer set timout callback error");
+		}
+		else
+		{
+			self->timeout_cb = RT_NULL;
+			self->timer_device->rx_indicate = RT_NULL;//注销回调函数
+		}
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_callback_obj, 0,machine_timer_callback);
+
 STATIC const mp_rom_map_elem_t machine_timer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_timer_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_timer_init_obj) },
+	{ MP_ROM_QSTR(MP_QSTR_callback), MP_ROM_PTR(&machine_timer_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_ONE_SHOT), MP_ROM_INT(RT_FALSE) },
     { MP_ROM_QSTR(MP_QSTR_PERIODIC), MP_ROM_INT(RT_TRUE) },
 };

--- a/port/modules/machine/machine_timer.c
+++ b/port/modules/machine/machine_timer.c
@@ -39,7 +39,6 @@
 #include <drivers/hwtimer.h>
 #include "machine_timer.h"
 
-#define  MAX_TIMER  17
 typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
     rt_device_t timer_device;
@@ -91,13 +90,12 @@ STATIC mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
     self->timeout_cb = RT_NULL;
     self->is_repeat = RT_TRUE;
     self->is_init = RT_FALSE;
-    self->timer_device->device_id = device_id-1;
     
     // return constant object
     return MP_OBJ_FROM_PTR(self);
 }
 
-static machine_timer_obj_t *timer_self[MAX_TIMER] = {RT_NULL};
+static machine_timer_obj_t *timer_self = RT_NULL;
 
 STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     machine_timer_obj_t *self = self_in;
@@ -107,7 +105,7 @@ STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
         result = rt_device_close(self->timer_device);
         error_check(result == RT_EOK, "Timer device close error");
         self->is_init = RT_FALSE;
-        timer_self[self->timer_device->device_id] = RT_NULL;
+        timer_self = RT_NULL;
     }
 
     return mp_const_none;
@@ -115,7 +113,7 @@ STATIC mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
 STATIC rt_err_t timer_event_handler(rt_device_t dev, rt_size_t size) {
-    machine_timer_obj_t *self = timer_self[dev->device_id];
+    machine_timer_obj_t *self = timer_self;
 
     mp_sched_schedule(self->timeout_cb, MP_OBJ_FROM_PTR(self));
     return RT_EOK;
@@ -164,11 +162,11 @@ STATIC mp_obj_t machine_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_ma
     
     if (self->timeout_cb != RT_NULL) {
         // set callback timer
-        if (timer_self[self->timer_device->device_id] && timer_self[self->timer_device->device_id] != self) {
+        if (timer_self && timer_self != self) {
             // TODO add multi-timer device support
             error_check(result == RT_EOK, "Only supports one timer device work");
         } else {
-            timer_self[self->timer_device->device_id] = self;
+            timer_self = self;
         }
         result = rt_device_set_rx_indicate(self->timer_device, timer_event_handler);
         error_check(result == RT_EOK, "Timer set timout callback error");
@@ -196,47 +194,9 @@ STATIC mp_obj_t machine_timer_init(mp_uint_t n_args, const mp_obj_t *args, mp_ma
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);
 
-
-STATIC mp_obj_t machine_timer_callback(mp_uint_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-    machine_timer_obj_t *self = (machine_timer_obj_t *)args[0];
-    rt_bool_t result = RT_EOK;
-    
-    static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_callback,     MP_ARG_OBJ, {.u_obj = mp_const_none} },
-    };
-
-    mp_arg_val_t dargs[MP_ARRAY_SIZE(allowed_args)];
-    mp_arg_parse_all(n_args - 1, args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, dargs);
-    
-    self->timeout_cb = dargs[0].u_obj;
-    
-    if(n_args == 1)
-    {
-        self->timeout_cb = RT_NULL;
-        self->timer_device->rx_indicate = RT_NULL;//注销回调函数
-    }
-    else if(n_args == 2)
-    {
-        if(self->timeout_cb != mp_const_none)
-        {
-            timer_self[self->timer_device->device_id] = self;
-            result = rt_device_set_rx_indicate(self->timer_device, timer_event_handler); //注册回调函数
-            error_check(result == RT_EOK, "Timer set timout callback error");
-        }
-        else
-        {
-            self->timeout_cb = RT_NULL;
-            self->timer_device->rx_indicate = RT_NULL;//注销回调函数
-        }
-    }
-    return mp_const_none;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_callback_obj, 0,machine_timer_callback);
-
 STATIC const mp_rom_map_elem_t machine_timer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_timer_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_timer_init_obj) },
-    { MP_ROM_QSTR(MP_QSTR_callback), MP_ROM_PTR(&machine_timer_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_ONE_SHOT), MP_ROM_INT(RT_FALSE) },
     { MP_ROM_QSTR(MP_QSTR_PERIODIC), MP_ROM_INT(RT_TRUE) },
 };


### PR DESCRIPTION
1.修改不能多个定时器同时使用回调函数的BUG
2.新增Callback方法，可在程序执行过程中随时修改回调函数和注销回调函数