### PR TITLE
fixed: compile err

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -25,7 +25,7 @@ path   += [cwd + '/port/modules/machine']
 LOCAL_CCFLAGS = ''
 
 if rtconfig.CROSS_TOOL == 'gcc':
-    LOCAL_CCFLAGS += ' -std=c99'
+    LOCAL_CCFLAGS += ' -std=gnu99'
 elif rtconfig.CROSS_TOOL == 'keil':
     LOCAL_CCFLAGS += ' --c99 --gnu'
 

--- a/port/mpgetcharport.c
+++ b/port/mpgetcharport.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <rtthread.h>
 #include <rtdevice.h>
 #include <rthw.h>


### PR DESCRIPTION
packages/micropython-latest/port/mpgetcharport.c:40:5: error: unknown
type name 'uint8_t'
     uint8_t ch;